### PR TITLE
Add support for using proper connection info

### DIFF
--- a/src/Wrapper/CakePHP/V2/CacheDsn.php
+++ b/src/Wrapper/CakePHP/V2/CacheDsn.php
@@ -19,6 +19,8 @@ class CacheDsn extends Dsn
     protected $defaultOptions = [
         'keyMap' => [
             'scheme' => 'engine',
+            'pass' => 'password',
+            'host' => 'server',
         ],
         'replacements' => [
             '/CACHE/' => CACHE


### PR DESCRIPTION
This adds better support for the RedisEngine.

Unfortunately, CakePHP uses `host`, `server`, and `servers` for configuring host information (lame) in various places. Would be nice if we could alias a single key as multiple - `host` as the three I mentioned - but that is outside of the scope of this PR.
