### PR TITLE
Fixes #11 (Rename `server` to `servers`)

### DIFF
--- a/src/Wrapper/CakePHP/V2/CacheDsn.php
+++ b/src/Wrapper/CakePHP/V2/CacheDsn.php
@@ -20,7 +20,7 @@ class CacheDsn extends Dsn
         'keyMap' => [
             'scheme' => 'engine',
             'pass' => 'password',
-            'host' => 'server',
+            'host' => 'servers',
         ],
         'replacements' => [
             '/CACHE/' => CACHE

--- a/tests/TestCase/Wrapper/CakePHP/V2/CacheDsnTest.php
+++ b/tests/TestCase/Wrapper/CakePHP/V2/CacheDsnTest.php
@@ -90,7 +90,7 @@ class CacheDsnTest extends PHPUnit_Framework_TestCase
                 'redis://user:password@hostname?prefix=APP_NAME_&duration=DURATION',
                 [
                     'engine' => 'Redis',
-                    'server' => 'hostname',
+                    'servers' => 'hostname',
                     'user' => 'user',
                     'password' => 'password',
                     'prefix' => 'test_app_',


### PR DESCRIPTION
Corrected CacheDsn’s key name from `server` to `servers` (see CakePHP
2.x’s MemcachedEngine for config options)
