### PR TITLE
Fixes #10 - URL decoding

### DIFF
--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -339,7 +339,6 @@ class Dsn
         if ($query) {
             foreach ($query as $key => &$value) {
                 if (is_array($value)) {
-
                     $intermediate = [];
                     foreach ($value as $k => $v) {
                         $v = urlencode($v);

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -239,6 +239,18 @@ class Dsn
 
         $url = array_merge($this->uriKeys, $url);
 
+        if (isset($url['host'])) {
+            $url['host'] = urldecode($url['host']);
+        }
+
+        if (isset($url['user'])) {
+            $url['user'] = urldecode($url['user']);
+        }
+
+        if (isset($url['pass'])) {
+            $url['pass'] = urldecode($url['pass']);
+        }
+
         foreach ($url as $key => $val) {
             $setter = 'set' . ucfirst($key);
             $this->$setter($val);
@@ -288,6 +300,18 @@ class Dsn
     protected function toUrlArray($data)
     {
         $url = array_intersect_key($data, $this->uriKeys);
+
+        if (isset($url['host'])) {
+            $url['host'] = urlencode($url['host']);
+        }
+
+        if (isset($url['user'])) {
+            $url['user'] = urlencode($url['user']);
+        }
+
+        if (isset($url['pass'])) {
+            $url['pass'] = urlencode($url['pass']);
+        }
 
         if ($url['adapter']) {
             $return = $url['scheme'] . '+' . $url['adapter'] . '://';

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -239,16 +239,12 @@ class Dsn
 
         $url = array_merge($this->uriKeys, $url);
 
-        if (isset($url['host'])) {
-            $url['host'] = urldecode($url['host']);
-        }
+        foreach (['host', 'user', 'pass'] as $key) {
+            if (!isset($url[$key])) {
+                continue;
+            }
 
-        if (isset($url['user'])) {
-            $url['user'] = urldecode($url['user']);
-        }
-
-        if (isset($url['pass'])) {
-            $url['pass'] = urldecode($url['pass']);
+            $url[$key] = urldecode($url[$key]);
         }
 
         foreach ($url as $key => $val) {
@@ -301,16 +297,12 @@ class Dsn
     {
         $url = array_intersect_key($data, $this->uriKeys);
 
-        if (isset($url['host'])) {
-            $url['host'] = urlencode($url['host']);
-        }
+        foreach (['host', 'user', 'pass'] as $key) {
+            if (!isset($url[$key])) {
+                continue;
+            }
 
-        if (isset($url['user'])) {
-            $url['user'] = urlencode($url['user']);
-        }
-
-        if (isset($url['pass'])) {
-            $url['pass'] = urlencode($url['pass']);
+            $url[$key] = urlencode($url[$key]);
         }
 
         if ($url['adapter']) {

--- a/tests/TestCase/Wrapper/CakePHP/V2/EmailDsnTest.php
+++ b/tests/TestCase/Wrapper/CakePHP/V2/EmailDsnTest.php
@@ -73,6 +73,21 @@ class EmailDsnTest extends PHPUnit_Framework_TestCase
                     'layout' => false,
                     'timeout' => 30,
                 ]
+            ],
+            [
+                'smtp://user:secret@ssl%3A%2F%2Flocalhost:465/?from=you@localhost&messageId=1&template=0&layout=0&timeout=30',
+                [
+                    'transport' => 'Smtp',
+                    'host' => 'ssl://localhost',
+                    'port' => 465,
+                    'username' => 'user',
+                    'password' => 'secret',
+                    'from' => 'you@localhost',
+                    'messageId' => true,
+                    'template' => false,
+                    'layout' => false,
+                    'timeout' => 30,
+                ]
             ]
         ];
     }

--- a/tests/TestCase/Wrapper/CakePHP/V3/EmailDsnTest.php
+++ b/tests/TestCase/Wrapper/CakePHP/V3/EmailDsnTest.php
@@ -79,6 +79,21 @@ class EmailDsnTest extends PHPUnit_Framework_TestCase
                     'layout' => false,
                     'timeout' => 30,
                 ]
+            ],
+            [
+                'smtp://user:secret@ssl%3A%2F%2Flocalhost:465/?from=you@localhost&messageId=1&template=0&layout=0&timeout=30',
+                [
+                    'className' => 'Smtp',
+                    'host' => 'ssl://localhost',
+                    'port' => 465,
+                    'username' => 'user',
+                    'password' => 'secret',
+                    'from' => 'you@localhost',
+                    'messageId' => true,
+                    'template' => false,
+                    'layout' => false,
+                    'timeout' => 30,
+                ]
             ]
         ];
     }


### PR DESCRIPTION
Fix for issue #10 - Add url decoding to dsn parts.

URL `host`, `user` and `pass` parameters are now encoded and decoded.
